### PR TITLE
Add Pygame Brownian motion simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# hello_world
+# Hello World
+
+This repository now contains a simple Brownian motion simulation using Pygame. The simulation displays several small balls moving within a rectangular window, bouncing off the walls as they undergo random motion.
+
+## Requirements
+- Python 3.11+
+- Pygame
+
+You can install dependencies with:
+```bash
+pip install pygame
+```
+
+## Running the Simulation
+Execute the following command to run the program:
+```bash
+python brownian_simulation.py
+```
+A window will appear showing multiple balls undergoing Brownian motion inside the box.

--- a/brownian_simulation.py
+++ b/brownian_simulation.py
@@ -1,0 +1,65 @@
+import random
+import pygame
+
+# Simulation parameters
+WIDTH, HEIGHT = 800, 600
+BACKGROUND_COLOR = (255, 255, 255)  # white background (transparent box concept)
+BALL_COLOR = (30, 144, 255)  # dodger blue
+NUM_BALLS = 20
+BALL_RADIUS = 10
+MAX_SPEED = 5
+
+pygame.init()
+
+screen = pygame.display.set_mode((WIDTH, HEIGHT))
+pygame.display.set_caption('Brownian Motion Simulation')
+clock = pygame.time.Clock()
+
+class Ball:
+    def __init__(self):
+        self.x = random.uniform(BALL_RADIUS, WIDTH - BALL_RADIUS)
+        self.y = random.uniform(BALL_RADIUS, HEIGHT - BALL_RADIUS)
+        self.vx = random.uniform(-MAX_SPEED, MAX_SPEED)
+        self.vy = random.uniform(-MAX_SPEED, MAX_SPEED)
+
+    def update(self):
+        # Add small random acceleration to simulate Brownian noise
+        self.vx += random.uniform(-1, 1)
+        self.vy += random.uniform(-1, 1)
+
+        # Limit speed
+        self.vx = max(min(self.vx, MAX_SPEED), -MAX_SPEED)
+        self.vy = max(min(self.vy, MAX_SPEED), -MAX_SPEED)
+
+        self.x += self.vx
+        self.y += self.vy
+
+        # Bounce off walls
+        if self.x <= BALL_RADIUS or self.x >= WIDTH - BALL_RADIUS:
+            self.vx = -self.vx
+            self.x = max(BALL_RADIUS, min(self.x, WIDTH - BALL_RADIUS))
+        if self.y <= BALL_RADIUS or self.y >= HEIGHT - BALL_RADIUS:
+            self.vy = -self.vy
+            self.y = max(BALL_RADIUS, min(self.y, HEIGHT - BALL_RADIUS))
+
+    def draw(self, surface):
+        pygame.draw.circle(surface, BALL_COLOR, (int(self.x), int(self.y)), BALL_RADIUS)
+
+balls = [Ball() for _ in range(NUM_BALLS)]
+
+running = True
+while running:
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            running = False
+
+    screen.fill(BACKGROUND_COLOR)
+
+    for ball in balls:
+        ball.update()
+        ball.draw(screen)
+
+    pygame.display.flip()
+    clock.tick(60)  # Limit to 60 FPS
+
+pygame.quit()


### PR DESCRIPTION
## Summary
- add a Pygame-based Brownian motion simulator
- update README with instructions for running the simulation

## Testing
- `python -m py_compile brownian_simulation.py`
- *(failed to run GUI-based script in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68464a125b10832ca504b8544c8407ea